### PR TITLE
Enhance webapp style and configurable API

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -71,6 +71,17 @@ Run the development server:
 npm run dev
 ```
 
+### Configuring the API base URL
+
+The generated REST client uses the `VITE_API_BASE_URL` environment variable.
+If not set, requests use a relative path, so the API must be hosted on the same
+origin. When deploying the webapp separately, provide the URL before building:
+
+```bash
+VITE_API_BASE_URL="https://myserver.example" npm run build
+```
+
+
 ## Testing
 
 Install dependencies and Playwright browsers:

--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -1,8 +1,7 @@
 #root {
-  max-width: 1280px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
 }
 
 .logo {

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Tabs, Upload, Button, Select, Switch, Spin, Slider } from 'antd';
+import { Tabs, Upload, Button, Select, Switch, Spin, Slider, Layout, Typography } from 'antd';
 import type { UploadProps } from 'antd';
 import type { DetectResponseDto, VerifyResponseDto } from './api';
 import { DetectionModel, DefaultService } from './api';
@@ -8,6 +8,8 @@ import DetectResult from './components/DetectResult';
 import VerifyResult from './components/VerifyResult';
 
 const { Dragger } = Upload;
+const { Header, Content } = Layout;
+const { Title } = Typography;
 
 function DetectTab() {
   const [file, setFile] = useState<File | null>(null);
@@ -177,12 +179,21 @@ function VerifyTab() {
 
 export default function App() {
   return (
-    <Tabs
-      defaultActiveKey="detect"
-      items={[
-        { key: 'detect', label: 'Detect', children: <DetectTab /> },
-        { key: 'verify', label: 'Verify', children: <VerifyTab /> }
-      ]}
-    />
+    <Layout style={{ background: 'transparent' }}>
+      <Header style={{ background: '#1677ff' }}>
+        <Title style={{ color: '#fff', margin: '14px 0' }} level={3}>
+          Signature Demo
+        </Title>
+      </Header>
+      <Content style={{ paddingTop: 24 }}>
+        <Tabs
+          defaultActiveKey="detect"
+          items={[
+            { key: 'detect', label: 'Detect', children: <DetectTab /> },
+            { key: 'verify', label: 'Verify', children: <VerifyTab /> }
+          ]}
+        />
+      </Content>
+    </Layout>
   );
 }

--- a/webapp/src/api/core/OpenAPI.ts
+++ b/webapp/src/api/core/OpenAPI.ts
@@ -20,7 +20,7 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    BASE: 'http://localhost:5217',
+    BASE: import.meta.env.VITE_API_BASE_URL ?? '',
     VERSION: '1.0.0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light;
+  color: #213547;
+  background-color: #f4f6fa;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -24,8 +24,8 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
+  padding: 2rem;
+  background-color: #fff;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -42,27 +42,16 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #e6f0ff;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 0.25s, border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  background-color: #d4e4ff;
+  border-color: #7aa2ff;
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}


### PR DESCRIPTION
## Summary
- lighten React UI colors and add padding
- adjust layout styling and add a colored header
- use `VITE_API_BASE_URL` for API base
- document how to configure REST base URL

## Testing
- `npm run test`
- `npm run test:e2e`
- `dotnet test SignatureVerification.sln -c Release` *(fails: missing submodules)*

------
https://chatgpt.com/codex/tasks/task_e_68891bb044988325b77238f22db7ac82