### PR TITLE
Fix relative path to ONNX models

### DIFF
--- a/SignatureVerification.Api/Program.cs
+++ b/SignatureVerification.Api/Program.cs
@@ -3,7 +3,7 @@ using SignatureVerification.Api.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var soDir = Path.GetFullPath(Path.Combine(builder.Environment.ContentRootPath, "..", "sigver", "so"));
+var soDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "sigver", "so"));
 var ld = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH");
 Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", string.IsNullOrEmpty(ld) ? soDir : $"{soDir}:{ld}");
 
@@ -11,20 +11,18 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.Services.AddSingleton<SignatureDetectionService>(sp =>
+builder.Services.AddSingleton<SignatureDetectionService>(_ =>
 {
-    var env = sp.GetRequiredService<IHostEnvironment>();
-    var basePath = Path.Combine(env.ContentRootPath, "..", "signature-detection");
-    var detrPath = Path.GetFullPath(Path.Combine(basePath, "conditional_detr_signature.onnx"));
-    var yoloPath = Path.GetFullPath(Path.Combine(basePath, "yolov8s.onnx"));
+    var basePath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "signature-detection"));
+    var detrPath = Path.Combine(basePath, "conditional_detr_signature.onnx");
+    var yoloPath = Path.Combine(basePath, "yolov8s.onnx");
     return new SignatureDetectionService(detrPath, yoloPath);
 });
 
 builder.Services.AddSingleton<SignatureVerificationService>(sp =>
 {
-    var env = sp.GetRequiredService<IHostEnvironment>();
     var detector = sp.GetRequiredService<SignatureDetectionService>();
-    var modelPath = Path.GetFullPath(Path.Combine(env.ContentRootPath, "..", "sigver", "models", "signet.onnx"));
+    var modelPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "sigver", "models", "signet.onnx"));
     return new SignatureVerificationService(detector, modelPath);
 });
 


### PR DESCRIPTION
## Summary
- load signature detection models using paths relative to the application directory

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68891f213ccc83258a1101b6b6154581