### PR TITLE
Add smoke tests for API endpoints

### DIFF
--- a/SignatureVerification.Api.Tests/SignatureApiSmokeTests.cs
+++ b/SignatureVerification.Api.Tests/SignatureApiSmokeTests.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace SignatureVerification.Api.Tests;
+
+public class SignatureApiSmokeTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public SignatureApiSmokeTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    private static WebApplicationFactory<Program> CreateFactoryWithLogger(
+        WebApplicationFactory<Program> factory,
+        TestLoggerProvider logger)
+        => factory.WithWebHostBuilder(builder =>
+            builder.ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+                logging.AddProvider(logger);
+            }));
+
+    [Fact]
+    public async Task SwaggerEndpoint_ReturnsOpenApiDocumentAndNoErrors()
+    {
+        using var logger = new TestLoggerProvider();
+        using var factory = CreateFactoryWithLogger(_factory, logger);
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/swagger/v1/swagger.json");
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("openapi", body);
+        Assert.DoesNotContain(logger.Logs, l => l.LogLevel >= LogLevel.Error);
+    }
+
+    [Fact]
+    public async Task DetectEndpoint_ReturnsSignaturesAndNoErrors()
+    {
+        using var logger = new TestLoggerProvider();
+        using var factory = CreateFactoryWithLogger(_factory, logger);
+        using var client = factory.CreateClient();
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
+        var imagePath = Path.Combine(root, "signature-detection", "dataset", "dataset1", "images", "HSqSXe_png_jpg.rf.611fb71db1258341f1311cb5fab43127.jpg");
+        await using var fs = File.OpenRead(imagePath);
+        using var content = new MultipartFormDataContent();
+        var fileContent = new StreamContent(fs);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/jpeg");
+        content.Add(fileContent, "file", Path.GetFileName(imagePath));
+
+        var response = await client.PostAsync("/signature/detect", content);
+        var body = await response.Content.ReadAsStringAsync();
+        if (response.IsSuccessStatusCode)
+        {
+            Assert.Contains("signatures", body);
+        }
+        else
+        {
+            Assert.False(string.IsNullOrWhiteSpace(body));
+        }
+        Assert.DoesNotContain(logger.Logs, l => l.LogLevel >= LogLevel.Error);
+    }
+
+    [Fact]
+    public async Task VerifyEndpoint_ReturnsResultAndNoErrors()
+    {
+        using var logger = new TestLoggerProvider();
+        using var factory = CreateFactoryWithLogger(_factory, logger);
+        using var client = factory.CreateClient();
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
+        var imagePath = Path.Combine(root, "signature-detection", "dataset", "dataset1", "images", "HSqSXe_png_jpg.rf.611fb71db1258341f1311cb5fab43127.jpg");
+        await using var fs1 = File.OpenRead(imagePath);
+        await using var fs2 = File.OpenRead(imagePath);
+        using var content = new MultipartFormDataContent();
+        var c1 = new StreamContent(fs1);
+        c1.Headers.ContentType = new MediaTypeHeaderValue("image/jpeg");
+        var c2 = new StreamContent(fs2);
+        c2.Headers.ContentType = new MediaTypeHeaderValue("image/jpeg");
+        content.Add(c1, "reference", Path.GetFileName(imagePath));
+        content.Add(c2, "candidate", Path.GetFileName(imagePath));
+
+        var response = await client.PostAsync("/signature/verify?detection=true", content);
+        var body = await response.Content.ReadAsStringAsync();
+        if (response.IsSuccessStatusCode)
+        {
+            Assert.Contains("forged", body, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.False(string.IsNullOrWhiteSpace(body));
+        }
+        Assert.DoesNotContain(logger.Logs, l => l.LogLevel >= LogLevel.Error);
+    }
+}
+
+internal sealed class TestLoggerProvider : ILoggerProvider
+{
+    public List<LogEntry> Logs { get; } = new();
+
+    public ILogger CreateLogger(string categoryName) => new ListLogger(Logs);
+
+    public void Dispose() { }
+
+    public sealed record LogEntry(LogLevel LogLevel, string Message);
+
+    private sealed class ListLogger : ILogger
+    {
+        private readonly List<LogEntry> _logs;
+
+        public ListLogger(List<LogEntry> logs) => _logs = logs;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => _logs.Add(new LogEntry(logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/SignatureVerification.Api/Program.cs
+++ b/SignatureVerification.Api/Program.cs
@@ -3,7 +3,8 @@ using SignatureVerification.Api.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var soDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "sigver", "so"));
+var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+var soDir = Path.Combine(root, "sigver", "so");
 var ld = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH");
 Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", string.IsNullOrEmpty(ld) ? soDir : $"{soDir}:{ld}");
 
@@ -13,7 +14,7 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddSingleton<SignatureDetectionService>(_ =>
 {
-    var basePath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "signature-detection"));
+    var basePath = Path.Combine(root, "signature-detection");
     var detrPath = Path.Combine(basePath, "conditional_detr_signature.onnx");
     var yoloPath = Path.Combine(basePath, "yolov8s.onnx");
     return new SignatureDetectionService(detrPath, yoloPath);
@@ -22,7 +23,7 @@ builder.Services.AddSingleton<SignatureDetectionService>(_ =>
 builder.Services.AddSingleton<SignatureVerificationService>(sp =>
 {
     var detector = sp.GetRequiredService<SignatureDetectionService>();
-    var basePath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "sigver", "models"));
+    var basePath = Path.Combine(root, "sigver", "models");
     var signetPath = Path.Combine(basePath, "signet.onnx");
     var signetFPath = Path.Combine(basePath, "signet_f_lambda_0.95.onnx");
     return new SignatureVerificationService(detector, signetPath, signetFPath);


### PR DESCRIPTION
## Summary
- add smoke tests hitting Swagger, detect, and verify API endpoints
- capture API logs and fail tests if endpoints emit error-level entries
- fix model and native library paths to resolve from repo root

## Testing
- `git submodule update --init --recursive`
- `cat signature-detection/conditional_detr_signature.onnx_parte_1 signature-detection/conditional_detr_signature.onnx_parte_2 > signature-detection/conditional_detr_signature.onnx`
- `~/.dotnet/dotnet test SignatureVerification.sln -c Release --logger "console;verbosity=detailed" -v m` *(fails: An unhandled exception has occurred while executing the request)*

------
https://chatgpt.com/codex/tasks/task_e_688b6f7da1308325b92f769b586bce1a