### PR TITLE
feat: log to console with serilog

### DIFF
--- a/SignatureVerification.Api/Program.cs
+++ b/SignatureVerification.Api/Program.cs
@@ -1,8 +1,13 @@
 using Microsoft.Extensions.DependencyInjection;
 using SignatureDetectionSdk;
 using SignatureVerification.Api.Services;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((ctx, cfg) => cfg
+    .MinimumLevel.Verbose()
+    .WriteTo.Console());
 
 var root = "/app";//Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
 var soDir = Path.Combine(root, "sigver", "so");

--- a/SignatureVerification.Api/SignatureVerification.Api.csproj
+++ b/SignatureVerification.Api/SignatureVerification.Api.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- set up Serilog in API to emit verbose logs to the console
- reference Serilog.AspNetCore package

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6890adf137988325a8d8b158fc9ebe51